### PR TITLE
fix: 修复因namesilo域名获取接口更新,导致裸域名情况下无法匹配域名的问题

### DIFF
--- a/update_namesilo.sh
+++ b/update_namesilo.sh
@@ -104,7 +104,7 @@ split_domain() {
     done
 
     # Check if it is naked domain
-    if _contains "$RESPONSE" "<domain>$domain</domain>"; then
+    if _contains "$RESPONSE" "<domain[^>]*>$domain</domain>"; then
         DOMAIN="$domain"
         write_log 7 "Domain $DOMAIN in NameSilo found"
         return 0 # Naked domain

--- a/update_namesilo_cn.sh
+++ b/update_namesilo_cn.sh
@@ -104,7 +104,7 @@ split_domain() {
     done
 
     # 检查是否是裸域名
-    if _contains "$RESPONSE" "<domain>$domain</domain>"; then
+    if _contains "$RESPONSE" "<domain[^>]*>$domain</domain>"; then
         DOMAIN="$domain"
         write_log 7 "Domain $DOMAIN in NameSilo found"
         return 0 # 裸域名


### PR DESCRIPTION
namesilo的listDomains api更新,增加了过期时间属性.导致`_contains`无法正确判断是否匹配.

旧的domain元素为`<domain>mysite.com</domain>`
新的domain元素为`<domain expires="2025-03-21">mysite.com</domain>`
所以现使用正则表达式匹配