### PR TITLE
fix: 修复namesilo更新api`listDomains`导致裸域名匹配失败的问题

### DIFF
--- a/update_namesilo.sh
+++ b/update_namesilo.sh
@@ -104,7 +104,7 @@ split_domain() {
     done
 
     # Check if it is naked domain
-    if _contains "$RESPONSE" "<domain>$domain</domain>"; then
+    if _contains "$RESPONSE" "<domain.*>$domain</domain>"; then
         DOMAIN="$domain"
         write_log 7 "Domain $DOMAIN in NameSilo found"
         return 0 # Naked domain

--- a/update_namesilo_cn.sh
+++ b/update_namesilo_cn.sh
@@ -104,7 +104,7 @@ split_domain() {
     done
 
     # 检查是否是裸域名
-    if _contains "$RESPONSE" "<domain>$domain</domain>"; then
+    if _contains "$RESPONSE" "<domain.*>$domain</domain>"; then
         DOMAIN="$domain"
         write_log 7 "Domain $DOMAIN in NameSilo found"
         return 0 # 裸域名


### PR DESCRIPTION
旧的domain元素为`<domain>mysite.com</domain>`
新的domain元素为`<domain expires="2025-03-21">mysite.com</domain>`
namesilo更新api导致裸域名无法正确匹配.
所以现修改裸域名匹配为正则匹配以修复这个问题