### PR TITLE
fix: 修复namesilo更新`listDomains`api导致裸域名匹配失败的问题

### DIFF
--- a/update_namesilo.sh
+++ b/update_namesilo.sh
@@ -104,7 +104,7 @@ split_domain() {
     done
 
     # Check if it is naked domain
-    if _contains "$RESPONSE" "<domain>$domain</domain>"; then
+    if _contains "$RESPONSE" "<domain.*>$domain</domain>"; then
         DOMAIN="$domain"
         write_log 7 "Domain $DOMAIN in NameSilo found"
         return 0 # Naked domain

--- a/update_namesilo_cn.sh
+++ b/update_namesilo_cn.sh
@@ -104,7 +104,7 @@ split_domain() {
     done
 
     # 检查是否是裸域名
-    if _contains "$RESPONSE" "<domain>$domain</domain>"; then
+    if _contains "$RESPONSE" "<domain.*>$domain</domain>"; then
         DOMAIN="$domain"
         write_log 7 "Domain $DOMAIN in NameSilo found"
         return 0 # 裸域名


### PR DESCRIPTION
## 问题描述
DDNS更新裸域名时(如`mysite.com`)提示`找不到指定的域名`

## 问题原因
namesilo的`listDomains`接口进行了升级,响应里的`domain`元素新增了`expires`属性用于标识域名过期时间

旧接口响应为`<domain>mysite.com</domain>`
新接口响应为`<domain expires="2025-03-21">mysite.com</domain>`

而原有代码使用精确匹配 导致裸域名无法正确匹配

## 如何解决问题

使用正则表达式匹配以修复该问题